### PR TITLE
fix(bug): configurable weather location from widget settings

### DIFF
--- a/src/stores/depthOSStore.ts
+++ b/src/stores/depthOSStore.ts
@@ -585,13 +585,17 @@ export const useDepthOSStore = create<DepthOSStore>()(
       updateWeatherData: (data) => set({ weatherData: data }),
 
       refreshWeather: () => {
+        // Get location from weather widget config, default to 'San Francisco'
+        const state = get();
+        const weatherWidget = state.workspaces.find(w => w.id === state.activeWorkspaceId)?.widgets?.find(w => w.type === 'weather');
+        const location = weatherWidget?.config?.location || 'San Francisco';
         const conditions: WeatherData['condition'][] = ['sunny', 'cloudy', 'rainy', 'snowy', 'stormy'];
         const data: WeatherData = {
           temperature: Math.floor(Math.random() * 30) + 10,
           condition: conditions[Math.floor(Math.random() * conditions.length)],
           humidity: Math.floor(Math.random() * 60) + 20,
           windSpeed: Math.floor(Math.random() * 30),
-          location: 'San Francisco',
+          location: location,
         };
         get().updateWeatherData(data);
       },


### PR DESCRIPTION
## Summary
This PR fixes issue #32 where the weather refresh used a hardcoded location.

### Changes
- Weather widget now reads location from weather widget config
- Falls back to "San Francisco" default if not configured
- Location can be set per-workspace via widget config

## Closes
- #32: Weather refresh uses hardcoded location instead of user-configured value

## Files Changed
| File | Change | Description |
|------|--------|-------------|
| src/stores/depthOSStore.ts | Fix | Read location from widget config |